### PR TITLE
Make it fast

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ install:
 	@npm install
 
 test: lint
-	@$(MOCHA) -s 10
+	multi='mocha-osx-reporter=- spec=-' $(MOCHA) -s 10 test/*.test.js --reporter mocha-multi
 
 watch:
-	@$(MOCHA) -w -s 10
+	multi='mocha-osx-reporter=- spec=-' $(MOCHA) -s 10 test/*.test.js --reporter mocha-multi -w
 
 coverage:
 	@$(ISTANBUL) cover $(_MOCHA) -- test/*.test.js -R dot

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ install:
 	@npm install
 
 test: lint
-	multi='mocha-osx-reporter=- spec=-' $(MOCHA) -s 10 test/*.test.js --reporter mocha-multi
+	multi='mocha-osx-reporter=- spec=-' $(MOCHA) -s 5 test/*.test.js --reporter mocha-multi
 
 watch:
-	multi='mocha-osx-reporter=- spec=-' $(MOCHA) -s 10 test/*.test.js --reporter mocha-multi -w
+	multi='mocha-osx-reporter=- spec=-' $(MOCHA) -s 5 test/*.test.js --reporter mocha-multi -w
 
 coverage:
 	@$(ISTANBUL) cover $(_MOCHA) -- test/*.test.js -R dot

--- a/README.md
+++ b/README.md
@@ -74,19 +74,30 @@ expect(expanded[3][0]).to.equal('2.4.01');
 = "1.1.01", "1.2.01", "1.3.01"
 ```
 
-## Custom matchers
+## Custom expander
 
-It is possible to add a custom *matcher callback*, a function which gets executed for each possible position within the range.
+It is possible to extend dilla-expressions with your own expression expander.
 
-The matcher function receives two arguments, arrays with bar, beat and tick values - for user defined expression, and possible matched position.
+The position is split into three fragments. An expander function will be called for each fragment of the position expression that is not a simple number or already expanded by a previous expander, i.e. wildcard, modulus, etc...
 
-The stack of matchers will continue to execute until a position has been accepted or until the stack ends.
+Start and end represent the start and endpoints for the current fragment, and would most times be the same as barsPerLoop, but could be another value if the expression is combined with the *greater than* or *less than* operators.
 
 ```js
-expr.addMatcher(function (exprFragments, posFragments) {
-  if (posFragments[2] === 45) return true;
-  return false;
+var expanded = expr([
+  ['foo.bar.baz']
+], {
+  'barsPerLoop': 2,
+  'beatsPerBar': 4,
+  'expander': function (fragment, start, end) {
+    if (fragment === 'foo') { return [1, 2]; }
+    else if (fragment === 'bar') { return [end/2]; }
+    else if (fragment === 'baz') { return [15]; }
+  }
 });
+
+expect(expanded.length).to.equal(2);
+expect(expanded[0][0]).to.equal('1.2.15');
+expect(expanded[1][0]).to.equal('2.2.15');
 ```
 
 ## Develop
@@ -109,6 +120,12 @@ expr.addMatcher(function (exprFragments, posFragments) {
   - FIXED: ```1.2%1.01``` expression would incorrectly match ```1.1.01```
 - **1.2.0**
   - NEW: greater than and less than operators
+- **2.0.0**
+  - NEW: completely refactored to improve performance
+    - Single expression: 23ms to 1ms (23x)
+    - Repeated single expression: 77ms to 1ms (77x)
+    - Large expression: 4,659ms to 3ms (1,553x)
+  - CHANGED: Removed ```expr.addMatcher``` in favor of ```options.expander``` fn for custom expander logic
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ It is possible to extend dilla-expressions with your own expression expander.
 
 The position is split into three fragments. An expander function will be called for each fragment of the position expression that is not a simple number or already expanded by a previous expander, i.e. wildcard, modulus, etc...
 
-Start and end represent the start and endpoints for the current fragment, and would most times be the same as barsPerLoop, but could be another value if the expression is combined with the *greater than* or *less than* operators.
+Start and end represent the start and endpoints for the current fragment, and would most times be the same as barsPerLoop, but could be another value if the fragment is combined with the *greater than* or *less than* operators.
 
 ```js
 var expanded = expr([

--- a/index.js
+++ b/index.js
@@ -1,8 +1,14 @@
-function isPlainPosition (position) {
-  return !!position.match(/^\d+\.\d+\.\d+$/);
+var memoize = require('lodash.memoize');
+
+function hashArgs () {
+  return [].slice.call(arguments).join('//');
 }
 
-function getPossiblePositions (barsPerLoop, beatsPerBar) {
+var isPlainPosition = memoize(function (position) {
+  return !!position.match(/^\d+\.\d+\.\d+$/);
+});
+
+var getPossiblePositions = memoize(function (barsPerLoop, beatsPerBar) {
   var possibles = [];
   var bar = 0, beat, tick, displayTick;
   while (++bar <= barsPerLoop) {
@@ -16,15 +22,15 @@ function getPossiblePositions (barsPerLoop, beatsPerBar) {
     }
   }
   return possibles;
-}
+}, hashArgs);
 
-function getFragments (position) {
+var getFragments = memoize(function  (position) {
   return position.split('.').map(function (fragment) {
     var fragmentNumber = parseInt(fragment, 10);
     if (fragment.match(/^\d+$/) && !isNaN(fragmentNumber)) return fragmentNumber;
     return fragment;
   });
-}
+});
 
 var matchers = [];
 
@@ -36,14 +42,14 @@ function addMatcher (matcher) {
 var gtRe = />(\d+)/;
 var ltRe = /<(\d+)/;
 
-function makeExpressionFunction (expression) {
+var makeExpressionFunction = memoize(function  (expression) {
   var exprFragments = getFragments(expression);
-  // console.log(exprFragments, expression)
-  return function expressionFn (position) {
+  return memoize(function (position) {
     var positionFragments = getFragments(position);
     var valid = true;
     exprFragments.some(function (exprFragment, index) {
       if (typeof exprFragment === 'number' && positionFragments[index] === exprFragment) return;
+      // console.log('>', positionFragments[index], index, exprFragment);
       exprFragment = '' + exprFragment;
 
       if (ltRe.test(exprFragment)) {
@@ -95,8 +101,8 @@ function makeExpressionFunction (expression) {
       }
     }
     return valid;
-  };
-}
+  });
+});
 
 function expressions (notes, options) {
 

--- a/index.js
+++ b/index.js
@@ -59,15 +59,15 @@ function expandToTree (fragment, tree, limit) {
     return;
   }
 
-  var gtMatch = 0, ltMatch = 0;
-
-  if (gtMatch = fragment.match(gtRe)) {
+  var gtMatch = fragment.match(gtRe) || 0;
+  if (gtMatch) {
     gtMatch = gtMatch && parseInt(gtMatch[1], 10);
     start = gtMatch + 1;
     fragment = fragment.replace(gtRe, '');
   }
 
-  if (ltMatch = fragment.match(ltRe)) {
+  var ltMatch = fragment.match(ltRe) || 0;
+  if (ltMatch) {
     ltMatch = ltMatch && parseInt(ltMatch[1], 10);
     limit = ltMatch - 1;
     fragment = fragment.replace(ltRe, '');
@@ -148,10 +148,6 @@ function expressions (notes, options) {
   });
 
   return all;
-  // return sort(all);
-  // return all.sort(function (a, b) {
-  //   return a < b ? -1 : a > b ? 1 : 0;
-  // });
 }
 
 module.exports = expressions;

--- a/index.js
+++ b/index.js
@@ -3,26 +3,31 @@ var memoize = require('lodash.memoize');
 function hashArgs () {
   return [].slice.call(arguments).join('//');
 }
+function serializeArgs () {
+  return [].slice.call(arguments).map(function (arg) {
+    return typeof arg === 'object' ? JSON.stringify(arg) : arg;
+  }).join('//');
+}
 
 var isPlainPosition = memoize(function (position) {
   return !!position.match(/^\d+\.\d+\.\d+$/);
 });
 
-var getPossiblePositions = memoize(function (barsPerLoop, beatsPerBar) {
-  var possibles = [];
-  var bar = 0, beat, tick, displayTick;
-  while (++bar <= barsPerLoop) {
-    beat = 0;
-    while (++beat <= beatsPerBar) {
-      tick = 0;
-      while (++tick <= 96) {
-        displayTick = tick < 10 ? '0' + tick : tick;
-        possibles.push([bar, beat, displayTick].join('.'));
-      }
-    }
-  }
-  return possibles;
-}, hashArgs);
+// var getPossiblePositions = memoize(function (barsPerLoop, beatsPerBar) {
+//   var possibles = [];
+//   var bar = 0, beat, tick, displayTick;
+//   while (++bar <= barsPerLoop) {
+//     beat = 0;
+//     while (++beat <= beatsPerBar) {
+//       tick = 0;
+//       while (++tick <= 96) {
+//         displayTick = tick < 10 ? '0' + tick : tick;
+//         possibles.push([bar, beat, displayTick].join('.'));
+//       }
+//     }
+//   }
+//   return possibles;
+// }, hashArgs);
 
 var getFragments = memoize(function  (position) {
   return position.split('.').map(function (fragment) {
@@ -32,77 +37,158 @@ var getFragments = memoize(function  (position) {
   });
 });
 
-var matchers = [];
+// var matchers = [];
 
-function addMatcher (matcher) {
-  if (!matcher || typeof matcher !== 'function') throw new Error('Invalid argument: matcher is not a function');
-  matchers.push(matcher);
+// function addMatcher (matcher) {
+//   if (!matcher || typeof matcher !== 'function') throw new Error('Invalid argument: matcher is not a function');
+//   matchers.push(matcher);
+// }
+
+// var gtRe = />(\d+)/;
+// var ltRe = /<(\d+)/;
+// var plain
+//
+// var makeExpressionFunction = memoize(function  (expression) {
+//   var exprFragments = getFragments(expression);
+//   return memoize(function (position) {
+//     var positionFragments = getFragments(position);
+//     var valid = true;
+//     exprFragments.some(function (exprFragment, index) {
+//       if (typeof exprFragment === 'number' && positionFragments[index] === exprFragment) return;
+//       // console.log('>', positionFragments[index], index, exprFragment);
+//       exprFragment = '' + exprFragment;
+//
+//       if (ltRe.test(exprFragment)) {
+//         var ltVal = exprFragment.match(ltRe)[1];
+//         exprFragment = exprFragment.replace(ltRe, '') || '*';
+//         if (positionFragments[index] >= ltVal) {
+//           valid = false;
+//           return true;
+//         }
+//       }
+//
+//       if (gtRe.test(exprFragment)) {
+//         var gtVal = exprFragment.match(gtRe)[1];
+//         exprFragment = exprFragment.replace(gtRe, '') || '*';
+//         if (positionFragments[index] <= gtVal) {
+//           valid = false;
+//           return true;
+//         }
+//       }
+//
+//       if (exprFragment === 'even' && positionFragments[index] % 2 === 0) return;
+//       if (exprFragment === 'odd' && positionFragments[index] % 2 === 1) return;
+//       if (exprFragment === '*') return;
+//
+//       if (typeof exprFragment === 'string' && exprFragment.indexOf('%') >= 0) {
+//         var nums = exprFragment.split('%');
+//         var offset = parseInt(nums[0] || 1, 10);
+//         var mod = parseInt(nums[1], 10);
+//         var value = positionFragments[index] - offset;
+//         if (mod === 1) {
+//           if (value >= 0) return;
+//         }
+//         else {
+//           var res = value % mod;
+//           if (!res) return;
+//         }
+//       }
+//       // position is invalid, break out early
+//       valid = false;
+//       return true;
+//     });
+//
+//     var _matchers = matchers.slice();
+//     var matcher;
+//     while (!valid && _matchers.length) {
+//       matcher = _matchers.shift();
+//       if (matcher(exprFragments, positionFragments)) {
+//         valid = true;
+//       }
+//     }
+//     return valid;
+//   });
+// });
+
+var skipInRange = memoize(function (limit, offset, step) {
+  var all = [];
+  while (offset <= limit) {
+    all.push(offset);
+    offset += step;
+  }
+  return all;
+}, serializeArgs);
+
+var getRange = memoize(function (limit) {
+  var all = [];
+  var i = 0;
+  while (i++ < limit) {
+    all.push(i);
+  }
+  return all;
+}, hashArgs);
+
+var filterModulus = memoize(function  (range, mod, res) {
+  return range.filter(function (n) {
+    return n % mod === res;
+  });
+}, hashArgs);
+
+function expandToTree (fragment, tree, limit) {
+  var range = getRange(limit);
+  if (/^\d+$/.test(fragment)) {
+    tree[fragment] = {};
+  }
+  else if (fragment === '*') {
+    range.forEach(function (n) {
+      tree[n] = {};
+    });
+  }
+  else if (fragment === 'odd' || fragment === 'even') {
+    var rest = fragment === 'even' ? 0 : 1;
+    filterModulus(range, 2, rest).forEach(function (n) {
+      tree[n] = {};
+    });
+  }
+  else if (typeof fragment === 'string' && ~fragment.indexOf('%')) {
+    var pieces = fragment.split('%')
+    var offset = pieces[0] && parseInt(pieces[0], 10) || 1;
+    var step = parseInt(pieces[1], 10);
+    skipInRange(limit, offset, step).forEach(function (n) {
+      tree[n] = {};
+    });
+  }
 }
 
-var gtRe = />(\d+)/;
-var ltRe = /<(\d+)/;
-
-var makeExpressionFunction = memoize(function  (expression) {
-  var exprFragments = getFragments(expression);
-  return memoize(function (position) {
-    var positionFragments = getFragments(position);
-    var valid = true;
-    exprFragments.some(function (exprFragment, index) {
-      if (typeof exprFragment === 'number' && positionFragments[index] === exprFragment) return;
-      // console.log('>', positionFragments[index], index, exprFragment);
-      exprFragment = '' + exprFragment;
-
-      if (ltRe.test(exprFragment)) {
-        var ltVal = exprFragment.match(ltRe)[1];
-        exprFragment = exprFragment.replace(ltRe, '') || '*';
-        if (positionFragments[index] >= ltVal) {
-          valid = false;
-          return true;
-        }
-      }
-
-      if (gtRe.test(exprFragment)) {
-        var gtVal = exprFragment.match(gtRe)[1];
-        exprFragment = exprFragment.replace(gtRe, '') || '*';
-        if (positionFragments[index] <= gtVal) {
-          valid = false;
-          return true;
-        }
-      }
-
-      if (exprFragment === 'even' && positionFragments[index] % 2 === 0) return;
-      if (exprFragment === 'odd' && positionFragments[index] % 2 === 1) return;
-      if (exprFragment === '*') return;
-
-      if (typeof exprFragment === 'string' && exprFragment.indexOf('%') >= 0) {
-        var nums = exprFragment.split('%');
-        var offset = parseInt(nums[0] || 1, 10);
-        var mod = parseInt(nums[1], 10);
-        var value = positionFragments[index] - offset;
-        if (mod === 1) {
-          if (value >= 0) return;
-        }
-        else {
-          var res = value % mod;
-          if (!res) return;
-        }
-      }
-      // position is invalid, break out early
-      valid = false;
-      return true;
+function flattenTree (tree) {
+  var all = [];
+  Object.keys(tree).forEach(function (bar) {
+    Object.keys(tree[bar]).forEach(function (beat) {
+      Object.keys(tree[bar][beat]).forEach(function (tick) {
+        tick = tick < 10 ? '0' + tick : tick;
+        all.push([bar, beat, tick].join('.'));
+      });
     });
+  })
+  return all;
+}
 
-    var _matchers = matchers.slice();
-    var matcher;
-    while (!valid && _matchers.length) {
-      matcher = _matchers.shift();
-      if (matcher(exprFragments, positionFragments)) {
-        valid = true;
-      }
-    }
-    return valid;
+var expandExpression = memoize(function (position, bars, beats) {
+  var fragments = getFragments(position);
+  var tree = {};
+
+  expandToTree(fragments[0], tree, bars);
+
+  Object.keys(tree).forEach(function (bar) {
+    expandToTree(fragments[1], tree[bar], beats);
+
+    Object.keys(tree[bar]).forEach(function (beat) {
+      expandToTree(fragments[2], tree[bar][beat], 96);
+    });
   });
-});
+
+  return flattenTree(tree);
+}, hashArgs);
 
 function expressions (notes, options) {
 
@@ -111,26 +197,24 @@ function expressions (notes, options) {
   if (typeof options.beatsPerBar !== 'number' || options.beatsPerBar < 0) throw new Error('Invalid options: beatsPerBar is not a valid number');
   if (typeof options.barsPerLoop !== 'number' || options.barsPerLoop < 0) throw new Error('Invalid options: barsPerLoop is not a valid number');
 
-  var possibles = getPossiblePositions(options.barsPerLoop, options.beatsPerBar);
   var all = [];
 
   notes.forEach(function (event) {
 
     var position = event[0];
     if (isPlainPosition(position)) return all.push(event);
-
-    var expressionFn = makeExpressionFunction(position);
-    possibles.filter(expressionFn).map(function (possible) {
+    expandExpression(position, options.barsPerLoop, options.beatsPerBar).forEach(function (expanded) {
       var clone = event.slice();
-      clone[0] = possible;
+      clone[0] = expanded;
       all.push(clone);
     });
   });
 
-  return all.sort(function (a, b) {
-    return a < b ? -1 : a > b ? 1 : 0;
-  });
+  return all;
+  // return sort(all);
+  // return all.sort(function (a, b) {
+  //   return a < b ? -1 : a > b ? 1 : 0;
+  // });
 }
 
-expressions.addMatcher = addMatcher;
 module.exports = expressions;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "codeclimate-test-reporter": "0.0.4",
     "istanbul": "^0.3.8",
     "jshint": "^2.6.3",
-    "mocha": "^2.2.1"
+    "mocha": "^2.2.1",
+    "mocha-multi": "^0.7.1",
+    "mocha-osx-reporter": "^0.1.2"
   },
   "dependencies": {
     "lodash.memoize": "^3.0.3"

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "istanbul": "^0.3.8",
     "jshint": "^2.6.3",
     "mocha": "^2.2.1"
+  },
+  "dependencies": {
+    "lodash.memoize": "^3.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dilla-expressions",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "expand expressions for repeating notes into flat positions",
   "main": "index.js",
   "scripts": {
@@ -30,7 +30,9 @@
     "jshint": "^2.6.3",
     "mocha": "^2.2.1",
     "mocha-multi": "^0.7.1",
-    "mocha-osx-reporter": "^0.1.2"
+    "mocha-osx-reporter": "^0.1.2",
+    "sinon": "^1.14.1",
+    "sinon-chai": "^2.7.0"
   },
   "dependencies": {
     "lodash.memoize": "^3.0.3"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -145,8 +145,6 @@ describe('when using wildcard expression', function () {
 
 describe('when using even/odd expression', function () {
 
-
-
   it('should repeat even beats', function () {
     var result = expr([
       ['1.even.10']
@@ -226,95 +224,97 @@ describe('when using even/odd expression', function () {
   });
 });
 
-describe('when no starting point is defined', function () {
-  it('should start from 1 and modulate every {n} ticks', function () {
-    var result = expr([
-      ['1.1.%30']
-    ], {
-      'beatsPerBar': 1,
-      'barsPerLoop': 1
+describe('when using modulus expression', function () {
+  describe('when no starting point is defined', function () {
+    it('should start from 1 and modulate every {n} ticks', function () {
+      var result = expr([
+        ['1.1.%30']
+      ], {
+        'beatsPerBar': 1,
+        'barsPerLoop': 1
+      });
+      expect(result.length).to.equal(4);
+      expect(result[0][0]).to.equal('1.1.01');
+      expect(result[1][0]).to.equal('1.1.31');
+      expect(result[2][0]).to.equal('1.1.61');
+      expect(result[3][0]).to.equal('1.1.91');
     });
-    expect(result.length).to.equal(4);
-    expect(result[0][0]).to.equal('1.1.01');
-    expect(result[1][0]).to.equal('1.1.31');
-    expect(result[2][0]).to.equal('1.1.61');
-    expect(result[3][0]).to.equal('1.1.91');
+
+    it('should start from 1 and modulate every {n} beats', function () {
+      var result = expr([
+        ['1.%3.01']
+      ], {
+        'beatsPerBar': 4,
+        'barsPerLoop': 1
+      });
+      expect(result.length).to.equal(2);
+      expect(result[0][0]).to.equal('1.1.01');
+      expect(result[1][0]).to.equal('1.4.01');
+    });
+
+    it('should start from 1 and modulate every {n} beats and ticks', function () {
+      var result = expr([
+        ['1.%3.%30']
+      ], {
+        'beatsPerBar': 4,
+        'barsPerLoop': 1
+      });
+      expect(result.length).to.equal(8);
+      expect(result[0][0]).to.equal('1.1.01');
+      expect(result[1][0]).to.equal('1.1.31');
+      expect(result[2][0]).to.equal('1.1.61');
+      expect(result[3][0]).to.equal('1.1.91');
+      expect(result[4][0]).to.equal('1.4.01');
+      expect(result[5][0]).to.equal('1.4.31');
+      expect(result[6][0]).to.equal('1.4.61');
+      expect(result[7][0]).to.equal('1.4.91');
+    });
   });
 
-  it('should start from 1 and modulate every {n} beats', function () {
-    var result = expr([
-      ['1.%3.01']
-    ], {
-      'beatsPerBar': 4,
-      'barsPerLoop': 1
-    });
-    expect(result.length).to.equal(2);
-    expect(result[0][0]).to.equal('1.1.01');
-    expect(result[1][0]).to.equal('1.4.01');
-  });
+  describe('when a starting point is defined', function () {
 
-  it('should start from 1 and modulate every {n} beats and ticks', function () {
-    var result = expr([
-      ['1.%3.%30']
-    ], {
-      'beatsPerBar': 4,
-      'barsPerLoop': 1
+    it('should start from it and modulate every {n} ticks', function () {
+      var result = expr([
+        ['1.1.5%20']
+      ], {
+        'beatsPerBar': 1,
+        'barsPerLoop': 1
+      });
+      expect(result.length).to.equal(5);
+      expect(result[0][0]).to.equal('1.1.05');
+      expect(result[1][0]).to.equal('1.1.25');
+      expect(result[2][0]).to.equal('1.1.45');
+      expect(result[3][0]).to.equal('1.1.65');
+      expect(result[4][0]).to.equal('1.1.85');
     });
-    expect(result.length).to.equal(8);
-    expect(result[0][0]).to.equal('1.1.01');
-    expect(result[1][0]).to.equal('1.1.31');
-    expect(result[2][0]).to.equal('1.1.61');
-    expect(result[3][0]).to.equal('1.1.91');
-    expect(result[4][0]).to.equal('1.4.01');
-    expect(result[5][0]).to.equal('1.4.31');
-    expect(result[6][0]).to.equal('1.4.61');
-    expect(result[7][0]).to.equal('1.4.91');
+
+    it('should start from it and modulate every {n} beats', function () {
+      var result = expr([
+        ['1.2%2.01']
+      ], {
+        'beatsPerBar': 4,
+        'barsPerLoop': 1
+      });
+      expect(result.length).to.equal(2);
+      expect(result[0][0]).to.equal('1.2.01');
+      expect(result[1][0]).to.equal('1.4.01');
+    });
+    it('should work with modulus 1, i.e. each after offset', function () {
+      var result = expr([
+        ['1.2%1.01']
+      ], {
+        'beatsPerBar': 4,
+        'barsPerLoop': 1
+      });
+      expect(result.length).to.equal(3);
+      expect(result[0][0]).to.equal('1.2.01');
+      expect(result[1][0]).to.equal('1.3.01');
+      expect(result[2][0]).to.equal('1.4.01');
+    });
   });
 });
 
-describe('when a starting point is defined', function () {
-
-  it('should start from it and modulate every {n} ticks', function () {
-    var result = expr([
-      ['1.1.5%20']
-    ], {
-      'beatsPerBar': 1,
-      'barsPerLoop': 1
-    });
-    expect(result.length).to.equal(5);
-    expect(result[0][0]).to.equal('1.1.05');
-    expect(result[1][0]).to.equal('1.1.25');
-    expect(result[2][0]).to.equal('1.1.45');
-    expect(result[3][0]).to.equal('1.1.65');
-    expect(result[4][0]).to.equal('1.1.85');
-  });
-
-  it('should start from it and modulate every {n} beats', function () {
-    var result = expr([
-      ['1.2%2.01']
-    ], {
-      'beatsPerBar': 4,
-      'barsPerLoop': 1
-    });
-    expect(result.length).to.equal(2);
-    expect(result[0][0]).to.equal('1.2.01');
-    expect(result[1][0]).to.equal('1.4.01');
-  });
-  it('should work with modulus 1, i.e. each after offset', function () {
-    var result = expr([
-      ['1.2%1.01']
-    ], {
-      'beatsPerBar': 4,
-      'barsPerLoop': 1
-    });
-    expect(result.length).to.equal(3);
-    expect(result[0][0]).to.equal('1.2.01');
-    expect(result[1][0]).to.equal('1.3.01');
-    expect(result[2][0]).to.equal('1.4.01');
-  });
-});
-
-describe('when "less than" and "greater than" expressions', function () {
+describe('when using "less than" and "greater than" expressions', function () {
 
   describe('when only "greater than" is defined', function () {
     it('should exclude less or same values', function () {
@@ -427,113 +427,113 @@ describe('when using mixed expression', function () {
   });
 });
 
-describe('addMatcher (matcher)', function () {
-  describe('when matcher is not a function', function () {
-    it('should throw an error', function () {
-      expect(function () {
-        expr.addMatcher();
-      }).to.throw(Error);
-      expect(function () {
-        expr.addMatcher('foo');
-      }).to.throw(Error);
-      expect(function () {
-        expr.addMatcher(1323);
-      }).to.throw(Error);
-      expect(function () {
-        expr.addMatcher({'pos': '1.1.01' });
-      }).to.throw(Error);
-      expect(function () {
-        expr.addMatcher(['1.1.1.1.1']);
-      }).to.throw(Error);
-    });
-  });
-
-  describe('when matcher is a function', function () {
-    it('should execute the matcher for each possible note', function () {
-      var count = 0;
-      var last = null;
-      expr.addMatcher(function (exprFragments, posFragments) {
-        count++;
-        last = posFragments.join('.');
-      });
-      expr([
-        ['1.1.*']
-      ], standardOptions);
-      expect(count).to.equal(672);
-      expect(last).to.equal('2.4.96');
-    });
-    describe('when matcher returns false', function () {
-      describe('when another rule matches', function () {
-        it('should include the note', function () {
-          expr.addMatcher(function (exprFragments, posFragments) {
-            if (posFragments.join('.') === '1.1.3') return false;
-          });
-          var result = expr([
-            ['1.1.odd']
-          ], standardOptions);
-          var found = result.filter(function (res) {
-            return res[0] === '1.1.03';
-          });
-          expect(found.length).to.equal(1);
-        });
-      });
-      describe('when no other rule matches', function () {
-        it('should not include the note', function () {
-          expr.addMatcher(function (exprFragments, posFragments) {
-            if (posFragments.join('.') === '1.1.2') return false;
-          });
-          var result = expr([
-            ['1.1.odd']
-          ], standardOptions);
-          var found = result.filter(function (res) {
-            return res[0] === '1.1.02';
-          });
-          expect(found.length).to.equal(0);
-        });
-      });
-    });
-    describe('when matcher returns true', function () {
-      describe('when a previous rule matches', function () {
-        it('should include the note', function () {
-          expr.addMatcher(function (exprFragments, posFragments) {
-            if (posFragments.join('.') === '1.1.5') return true;
-          });
-          var result = expr([
-            ['1.1.odd']
-          ], standardOptions);
-          var found = result.filter(function (res) {
-            return res[0] === '1.1.05';
-          });
-          expect(found.length).to.equal(1);
-        });
-        it('should not execute matcher', function () {
-          var count = 0;
-          expr.addMatcher(function (exprFragments, posFragments) {
-            return true;
-          });
-          expr.addMatcher(function (exprFragments, posFragments) {
-            count++;
-          });
-          var result = expr([
-            ['1.1.*']
-          ], standardOptions);
-          expect(count).to.equal(0);
-        });
-      });
-      describe('when no other rule matches', function () {
-        it('should include the note', function () {
-          expr.addMatcher(function (exprFragments, posFragments) {
-            if (posFragments.join('.') === '1.1.4') return true;
-          });
-          var result = expr([
-            ['1.1.foo']
-          ], standardOptions);
-          var found = result.filter(function (res) {
-            return res[0] === '1.1.04';
-          });
-          expect(found.length).to.equal(1);
-        });
-      });
-    });
-  });
-});
+// describe('addMatcher (matcher)', function () {
+//   describe('when matcher is not a function', function () {
+//     it('should throw an error', function () {
+//       expect(function () {
+//         expr.addMatcher();
+//       }).to.throw(Error);
+//       expect(function () {
+//         expr.addMatcher('foo');
+//       }).to.throw(Error);
+//       expect(function () {
+//         expr.addMatcher(1323);
+//       }).to.throw(Error);
+//       expect(function () {
+//         expr.addMatcher({'pos': '1.1.01' });
+//       }).to.throw(Error);
+//       expect(function () {
+//         expr.addMatcher(['1.1.1.1.1']);
+//       }).to.throw(Error);
+//     });
+//   });
+//
+//   describe('when matcher is a function', function () {
+//     it('should execute the matcher for each possible note', function () {
+//       var count = 0;
+//       var last = null;
+//       expr.addMatcher(function (exprFragments, posFragments) {
+//         count++;
+//         last = posFragments.join('.');
+//       });
+//       expr([
+//         ['1.1.*']
+//       ], standardOptions);
+//       expect(count).to.equal(672);
+//       expect(last).to.equal('2.4.96');
+//     });
+//     describe('when matcher returns false', function () {
+//       describe('when another rule matches', function () {
+//         it('should include the note', function () {
+//           expr.addMatcher(function (exprFragments, posFragments) {
+//             if (posFragments.join('.') === '1.1.3') return false;
+//           });
+//           var result = expr([
+//             ['1.1.odd']
+//           ], standardOptions);
+//           var found = result.filter(function (res) {
+//             return res[0] === '1.1.03';
+//           });
+//           expect(found.length).to.equal(1);
+//         });
+//       });
+//       describe('when no other rule matches', function () {
+//         it('should not include the note', function () {
+//           expr.addMatcher(function (exprFragments, posFragments) {
+//             if (posFragments.join('.') === '1.1.2') return false;
+//           });
+//           var result = expr([
+//             ['1.1.odd']
+//           ], standardOptions);
+//           var found = result.filter(function (res) {
+//             return res[0] === '1.1.02';
+//           });
+//           expect(found.length).to.equal(0);
+//         });
+//       });
+//     });
+//     describe('when matcher returns true', function () {
+//       describe('when a previous rule matches', function () {
+//         it('should include the note', function () {
+//           expr.addMatcher(function (exprFragments, posFragments) {
+//             if (posFragments.join('.') === '1.1.5') return true;
+//           });
+//           var result = expr([
+//             ['1.1.odd']
+//           ], standardOptions);
+//           var found = result.filter(function (res) {
+//             return res[0] === '1.1.05';
+//           });
+//           expect(found.length).to.equal(1);
+//         });
+//         it('should not execute matcher', function () {
+//           var count = 0;
+//           expr.addMatcher(function (exprFragments, posFragments) {
+//             return true;
+//           });
+//           expr.addMatcher(function (exprFragments, posFragments) {
+//             count++;
+//           });
+//           var result = expr([
+//             ['1.1.*']
+//           ], standardOptions);
+//           expect(count).to.equal(0);
+//         });
+//       });
+//       describe('when no other rule matches', function () {
+//         it('should include the note', function () {
+//           expr.addMatcher(function (exprFragments, posFragments) {
+//             if (posFragments.join('.') === '1.1.4') return true;
+//           });
+//           var result = expr([
+//             ['1.1.foo']
+//           ], standardOptions);
+//           var found = result.filter(function (res) {
+//             return res[0] === '1.1.04';
+//           });
+//           expect(found.length).to.equal(1);
+//         });
+//       });
+//     });
+//   });
+// });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -145,31 +145,7 @@ describe('when using wildcard expression', function () {
 
 describe('when using even/odd expression', function () {
 
-  it('should repeat even bars', function () {
-    var result = expr([
-      ['even.2.45']
-    ], {
-      'beatsPerBar': 4,
-      'barsPerLoop': 4
-    });
-    expect(result.length).to.equal(2);
-    expect(result[0][0]).to.equal('2.2.45');
-    expect(result[1][0]).to.equal('4.2.45');
-  });
 
-  it('should repeat odd bars', function () {
-    var result = expr([
-      ['odd.1.25']
-    ], {
-      'beatsPerBar': 4,
-      'barsPerLoop': 8
-    });
-    expect(result.length).to.equal(4);
-    expect(result[0][0]).to.equal('1.1.25');
-    expect(result[1][0]).to.equal('3.1.25');
-    expect(result[2][0]).to.equal('5.1.25');
-    expect(result[3][0]).to.equal('7.1.25');
-  });
 
   it('should repeat even beats', function () {
     var result = expr([

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -509,7 +509,7 @@ describe('benchmark', function () {
       expect(new Date() - start).to.be.lessThan(4);
     });
   });
-  describe('when adding a "normal" set of notes', function () {
+  describe('when adding a large set of expressions', function () {
     it('should not be slow', function () {
       this.timeout(5000);
       var start = new Date();
@@ -566,7 +566,7 @@ describe('benchmark', function () {
       [drum, hihat, lead, follow, bass].forEach(function (pattern) {
         expr(pattern, options);
       });
-      expect(new Date() - start).to.be.lessThan(6);
+      expect(new Date() - start).to.be.lessThan(7);
     });
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -490,83 +490,85 @@ describe('options.expander (expander)', function () {
   });
 });
 
-describe('benchmark', function () {
-  describe('when adding a single expression', function () {
-    it('should not be slow', function () {
-      var start = new Date();
-      var result = expr([
-        ['*.*.*']
-      ], standardOptions);
-      expect(new Date() - start).to.be.lessThan(2);
-    });
-  });
-  describe('when repeating a single expression', function () {
-    it('should not be slow', function () {
-      var start = new Date();
-      expr([['*.*.*']], standardOptions);
-      expr([['*.*.*']], standardOptions);
-      expr([['*.*.*']], standardOptions);
-      expect(new Date() - start).to.be.lessThan(4);
-    });
-  });
-  describe('when adding a large set of expressions', function () {
-    it('should not be slow', function () {
-      this.timeout(5000);
-      var start = new Date();
-      var options = {
-        beatsPerBar: 4,
-        barsPerLoop: 8
-      };
-      var drum = [
-        ['odd.1.01', 'A01'],
-        ['odd.1.51', 'A01'],
-        ['odd.1.91', 'A02'],
-        ['odd.2.88', 'A01'],
-        ['odd.3.75', 'A01'],
-        ['odd.3.91', 'A02'],
-        ['odd.4.72', 'A01'],
-        ['even.1.91', 'A02'],
-        ['even.1.51', 'A01'],
-        ['even.3.51', 'A01'],
-        ['even.3.88', 'A01'],
-        ['even.4.03', 'A02']
-      ];
-      var hihat = [
-        ['*.odd.01', 'A03'],
-        ['*.even.01', 'A03'],
-        ['*.4.53', 'A03']
-      ];
-      var lead = [
-        ['odd.1.01', 'B01'],
-        ['odd.4.90', 'B02'],
-        ['even.1.52', 'B02']
-      ];
-      var follow = [
-        ['odd.2.05', 'C03'],
-        ['odd.2.51', 'C03'],
-        ['odd.3.05', 'C03'],
-        ['odd.3.51', 'C03'],
-        ['odd.3.75', 'C01'],
-        ['odd.4.52', 'C01'],
-        ['even.2.05', 'C03'],
-        ['even.2.50', 'C02'],
-        ['even.3.25', 'C01'],
-        ['even.4.01', 'C01'],
-        ['even.4.75', 'C01']
-      ];
-      var bass = [
-        ['odd.1.01', 'D01'],
-        ['odd.2.72', 'D01'],
-        ['odd.3.02', 'D01'],
-        ['odd.4.01', 'D01'],
-        ['odd.4.51', 'D01'],
-        ['even.3.51', 'D01'],
-        ['even.4.51', 'D01']
-      ];
-      [drum, hihat, lead, follow, bass].forEach(function (pattern) {
-        expr(pattern, options);
+if (!process.env.running_under_istanbul) {
+  describe('benchmark', function () {
+    describe('when adding a single expression', function () {
+      it('should not be slow', function () {
+        var start = new Date();
+        var result = expr([
+          ['*.*.*']
+        ], standardOptions);
+        expect(new Date() - start).to.be.lessThan(2);
       });
-      expect(new Date() - start).to.be.lessThan(7);
+    });
+    describe('when repeating a single expression', function () {
+      it('should not be slow', function () {
+        var start = new Date();
+        expr([['*.*.*']], standardOptions);
+        expr([['*.*.*']], standardOptions);
+        expr([['*.*.*']], standardOptions);
+        expect(new Date() - start).to.be.lessThan(4);
+      });
+    });
+    describe('when adding a large set of expressions', function () {
+      it('should not be slow', function () {
+        this.timeout(5000);
+        var start = new Date();
+        var options = {
+          beatsPerBar: 4,
+          barsPerLoop: 8
+        };
+        var drum = [
+          ['odd.1.01', 'A01'],
+          ['odd.1.51', 'A01'],
+          ['odd.1.91', 'A02'],
+          ['odd.2.88', 'A01'],
+          ['odd.3.75', 'A01'],
+          ['odd.3.91', 'A02'],
+          ['odd.4.72', 'A01'],
+          ['even.1.91', 'A02'],
+          ['even.1.51', 'A01'],
+          ['even.3.51', 'A01'],
+          ['even.3.88', 'A01'],
+          ['even.4.03', 'A02']
+        ];
+        var hihat = [
+          ['*.odd.01', 'A03'],
+          ['*.even.01', 'A03'],
+          ['*.4.53', 'A03']
+        ];
+        var lead = [
+          ['odd.1.01', 'B01'],
+          ['odd.4.90', 'B02'],
+          ['even.1.52', 'B02']
+        ];
+        var follow = [
+          ['odd.2.05', 'C03'],
+          ['odd.2.51', 'C03'],
+          ['odd.3.05', 'C03'],
+          ['odd.3.51', 'C03'],
+          ['odd.3.75', 'C01'],
+          ['odd.4.52', 'C01'],
+          ['even.2.05', 'C03'],
+          ['even.2.50', 'C02'],
+          ['even.3.25', 'C01'],
+          ['even.4.01', 'C01'],
+          ['even.4.75', 'C01']
+        ];
+        var bass = [
+          ['odd.1.01', 'D01'],
+          ['odd.2.72', 'D01'],
+          ['odd.3.02', 'D01'],
+          ['odd.4.01', 'D01'],
+          ['odd.4.51', 'D01'],
+          ['even.3.51', 'D01'],
+          ['even.4.51', 'D01']
+        ];
+        [drum, hihat, lead, follow, bass].forEach(function (pattern) {
+          expr(pattern, options);
+        });
+        expect(new Date() - start).to.be.lessThan(6);
+      });
     });
   });
-});
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -420,9 +420,9 @@ describe('when using mixed expression', function () {
         'barsPerLoop': 1
       });
       expect(result.length).to.equal(3);
-      expect(result[0][0]).to.equal('1.10.01');
-      expect(result[1][0]).to.equal('1.13.01');
-      expect(result[2][0]).to.equal('1.7.01');
+      expect(result[0][0]).to.equal('1.7.01');
+      expect(result[1][0]).to.equal('1.10.01');
+      expect(result[2][0]).to.equal('1.13.01');
     });
   });
 });


### PR DESCRIPTION
The performance of dilla-expressions is still a bottleneck for Bap, even with the JITS refactor. No wonder, it was in a very inefficient way, and now it's time to change that.
- [x] memoize everything
- [x] object tree approach, instead of filtering all possibilites
- [x] add equivalent to `addMatcher()`
- [x] update readme
- [ ] release `v2.0`
